### PR TITLE
fix nonce error

### DIFF
--- a/zaifapi/impl.py
+++ b/zaifapi/impl.py
@@ -195,7 +195,7 @@ class _AbsZaifTradeApi(AbsZaifApi):
     def _get_nonce():
         now = datetime.now()
         nonce = str(int(time.mktime(now.timetuple())))
-        microseconds = str(now.microsecond)
+        microseconds = '{0:06d}'.format(now.microsecond)
         return Decimal(nonce + '.' + microseconds)
 
     def _get_parameter(self, func_name, params):


### PR DESCRIPTION
タイミングによってnonceがエラーになる
例えばmicrosecondsが000020の時に文字列上.2で連結されるということではなかろうか。