### PR TITLE
APIの接続プロトコル、ドメインなどを変更して実行できるように修正

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='zaifapi',
-    version='1.6.2',
+    version='1.6.3',
     description='Zaif Api Library',
     long_description='https://pypi.python.org/pypi/zaifapi',
     url='https://github.com/techbureau/zaifapi',
@@ -17,5 +17,5 @@ setup(
       'Intended Audience :: Developers',
       'License :: OSI Approved :: MIT License'
     ],
-    install_requires=['requests', 'websocket-client', 'Cerberus']
+    install_requires=['requests==2.19.1', 'websocket-client==0.48.0', 'Cerberus==1.2']
 )

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
       'Intended Audience :: Developers',
       'License :: OSI Approved :: MIT License'
     ],
-    install_requires=['requests==2.19.1', 'websocket-client==0.48.0', 'Cerberus==1.2']
+    install_requires=['requests', 'websocket-client', 'Cerberus']
 )

--- a/zaifapi/api_common/__init__.py
+++ b/zaifapi/api_common/__init__.py
@@ -1,7 +1,7 @@
 import inspect
 from abc import ABCMeta
 from .response import get_response
-from .url import ApiUrl
+from .url import ApiUrl, get_api_url
 from .validator import ZaifApiValidator, FuturesPublicApiValidator
 
 

--- a/zaifapi/api_common/url.py
+++ b/zaifapi/api_common/url.py
@@ -89,3 +89,9 @@ class QueryParam:
 
     def __dict__(self):
         return self._params
+
+
+def get_api_url(arg_api_url, api_name, protocol='https', host='api.zaif.jp', version=None, dirs=None, port=None):
+    if arg_api_url is not None:
+        return arg_api_url
+    return ApiUrl(api_name, protocol=protocol, host=host, version=version, dirs=dirs, port=port)

--- a/zaifapi/exchange_api/public.py
+++ b/zaifapi/exchange_api/public.py
@@ -4,7 +4,7 @@ from abc import ABCMeta
 
 from zaifapi.api_error import ZaifApiError
 from websocket import create_connection
-from zaifapi.api_common import method_name, ApiUrl, FuturesPublicApiValidator
+from zaifapi.api_common import method_name, get_api_url, FuturesPublicApiValidator
 from . import ZaifExchangeApi
 
 
@@ -25,8 +25,8 @@ class _ZaifPublicApiBase(ZaifExchangeApi, metaclass=ABCMeta):
 
 
 class ZaifPublicApi(_ZaifPublicApiBase):
-    def __init__(self):
-        super().__init__(ApiUrl(api_name='api', version=1))
+    def __init__(self, api_url=None):
+        super().__init__(get_api_url(api_url, 'api', version=1))
 
     def last_price(self, currency_pair):
         schema_keys = ['currency_pair']
@@ -66,9 +66,10 @@ class ZaifPublicApi(_ZaifPublicApiBase):
 
 
 class ZaifFuturesPublicApi(_ZaifPublicApiBase):
-    def __init__(self):
+    def __init__(self, api_url=None):
+        api_url = get_api_url(api_url, 'fapi', version=1)
         super().__init__(
-            ApiUrl(api_name='fapi', version=1),
+            api_url,
             FuturesPublicApiValidator()
         )
 
@@ -138,11 +139,9 @@ class ZaifFuturesPublicApi(_ZaifPublicApiBase):
 
 
 class ZaifPublicStreamApi(_ZaifPublicApiBase):
-    def __init__(self):
-        super().__init__(ApiUrl(api_name='stream',
-                                protocol='wss',
-                                host='ws.zaif.jp',
-                                port=8888))
+    def __init__(self, api_url=None):
+        api_url = get_api_url(api_url, 'stream', protocol='wss', host='ws.zaif.jp', port=8888)
+        super().__init__(api_url)
         self._continue = True
 
     def stop(self):

--- a/zaifapi/exchange_api/trade.py
+++ b/zaifapi/exchange_api/trade.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from datetime import datetime
 from abc import ABCMeta, abstractmethod
 from urllib.parse import urlencode
-from zaifapi.api_common import get_response, ApiUrl, method_name
+from zaifapi.api_common import get_response, get_api_url, method_name
 from zaifapi.api_error import ZaifApiError, ZaifApiNonceError
 from . import ZaifExchangeApi
 
@@ -55,8 +55,8 @@ def _make_signature(key, secret, params):
 
 
 class ZaifTradeApi(_ZaifTradeApiBase):
-    def __init__(self, key, secret):
-        super().__init__(ApiUrl(api_name='tapi'))
+    def __init__(self, key, secret, api_url=None):
+        super().__init__(get_api_url(api_url, 'tapi'))
         self._key = key
         self._secret = secret
 
@@ -112,8 +112,9 @@ class ZaifTradeApi(_ZaifTradeApiBase):
 
 
 class ZaifLeverageTradeApi(_ZaifTradeApiBase):
-    def __init__(self, key, secret):
-        super().__init__(ApiUrl(api_name='tlapi'))
+    def __init__(self, key, secret, api_url=None):
+        api_url = get_api_url(api_url, 'tlapi')
+        super().__init__(api_url)
         self._key = key
         self._secret = secret
 
@@ -151,9 +152,9 @@ class ZaifLeverageTradeApi(_ZaifTradeApiBase):
 
 
 class ZaifTokenTradeApi(ZaifTradeApi):
-    def __init__(self, token):
+    def __init__(self, token, api_url=None):
         self._token = token
-        super().__init__(None, None)
+        super().__init__(None, None, api_url)
 
     def get_header(self, params):
         return {

--- a/zaifapi/oauth.py
+++ b/zaifapi/oauth.py
@@ -1,14 +1,11 @@
 from zaifapi.api_common import get_response, ZaifApi
-from zaifapi.api_common import ApiUrl
+from zaifapi.api_common import get_api_url
 
 
 class ZaifTokenApi(ZaifApi):
-    def __init__(self, client_id, client_secret):
-        super().__init__(ApiUrl(api_name=None,
-                                version='v1',
-                                dirs=['token'],
-                                host='oauth.zaif.jp'))
-
+    def __init__(self, client_id, client_secret, api_url=None):
+        api_url = get_api_url(api_url, None, host='oauth.zaif.jp', version='v1', dirs=['token'])
+        super().__init__(api_url)
         self._client_id = client_id
         self._client_secret = client_secret
 


### PR DESCRIPTION
まえまえからやろうとおもってたのでいい機会でした

```
from zaifapi.api_common import ApiUrl
from zaifapi import ZaifPublicApi
api_url = ApiUrl('tapi', protocol='http', host='api.zaifzaif.jp')
public_api = ZaifPublicApi(api_url)
nedan = public_api.last_price('btc_jpy')
```

こんな感じの使い方を想定
@hhatto 